### PR TITLE
feat: turns out npm won't accept "download" in pkg name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-native-background-download-queue
+# react-native-background-downloader-queue
 
 [![npm package][npm-img]][npm-url]
 [![Build Status][build-img]][build-url]
@@ -25,17 +25,17 @@ First install peer dependencies:
 Once those are done, install this package:
 
 ```bash
-npm install react-native-background-download-queue
+npm install react-native-background-downloader-queue
 ```
 or
 ```bash
-yarn add react-native-background-download-queue
+yarn add react-native-background-downloader-queue
 ```
 
 ## Example
 
 ```Typescript
-import DownloadQueue from "react-native-background-download-queue";
+import DownloadQueue from "react-native-background-downloader-queue";
 
 new DownloadQueue({
   onBegin: (url, bytes) => console.log("Download started", url, bytes),
@@ -97,16 +97,16 @@ Resumes all active downloads that were previously paused. If you `init()` with `
 Gets a remote or local url, preferring to the local path when possible. If the local file hasn't yet been downloaded, returns the remote url.
 
 
-[build-img]:https://github.com/fivecar/react-native-background-download-queue/actions/workflows/release.yml/badge.svg
-[build-url]:https://github.com/fivecar/react-native-background-download-queue/actions/workflows/release.yml
-[downloads-img]:https://img.shields.io/npm/dt/react-native-background-download-queue
-[downloads-url]:https://www.npmtrends.com/react-native-background-download-queue
-[npm-img]:https://img.shields.io/npm/v/react-native-background-download-queue
-[npm-url]:https://www.npmjs.com/package/react-native-background-download-queue
-[issues-img]:https://img.shields.io/github/issues/fivecar/react-native-background-download-queue
-[issues-url]:https://github.com/fivecar/react-native-background-download-queue/issues
-[codecov-img]:https://codecov.io/gh/fivecar/react-native-background-download-queue/branch/main/graph/badge.svg
-[codecov-url]:https://codecov.io/gh/fivecar/react-native-background-download-queue
+[build-img]:https://github.com/fivecar/react-native-background-downloader-queue/actions/workflows/release.yml/badge.svg
+[build-url]:https://github.com/fivecar/react-native-background-downloader-queue/actions/workflows/release.yml
+[downloads-img]:https://img.shields.io/npm/dt/react-native-background-downloader-queue
+[downloads-url]:https://www.npmtrends.com/react-native-background-downloader-queue
+[npm-img]:https://img.shields.io/npm/v/react-native-background-downloader-queue
+[npm-url]:https://www.npmjs.com/package/react-native-background-downloader-queue
+[issues-img]:https://img.shields.io/github/issues/fivecar/react-native-background-downloader-queue
+[issues-url]:https://github.com/fivecar/react-native-background-downloader-queue/issues
+[codecov-img]:https://codecov.io/gh/fivecar/react-native-background-downloader-queue/branch/main/graph/badge.svg
+[codecov-url]:https://codecov.io/gh/fivecar/react-native-background-downloader-queue
 [semantic-release-img]:https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
 [semantic-release-url]:https://github.com/semantic-release/semantic-release
 [commitizen-img]:https://img.shields.io/badge/commitizen-friendly-brightgreen.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-native-background-download-queue",
-  "version": "0.0.0-development",
+  "name": "react-native-background-downloader-queue",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-native-background-download-queue",
-      "version": "0.0.0-development",
+      "name": "react-native-background-downloader-queue",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "key-value-file-system": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-background-download-queue",
-  "version": "1.0.0",
-  "description": "A wifi-aware background downloader that maintains a queue of files",
+  "name": "react-native-background-downloader-queue",
+  "version": "1.3.2",
+  "description": "A background downloader that works even when your app has quit, and maintains a queue of files so you don't have to babysit it.",
   "main": "./lib/index.js",
   "files": [
     "lib/**/*"
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fivecar/react-native-background-download-queue.git"
+    "url": "git+https://github.com/fivecar/react-native-background-downloader-queue.git"
   },
   "license": "MIT",
   "author": {
@@ -31,12 +31,17 @@
     "node": ">=12.0"
   },
   "keywords": [
-    "stuff"
+    "download",
+    "downloader",
+    "background",
+    "files",
+    "react-native",
+    "queue"
   ],
   "bugs": {
-    "url": "https://github.com/fivecar/react-native-background-download-queue/issues"
+    "url": "https://github.com/fivecar/react-native-background-downloader-queue/issues"
   },
-  "homepage": "https://github.com/fivecar/react-native-background-download-queue#readme",
+  "homepage": "https://github.com/fivecar/react-native-background-downloader-queue#readme",
   "devDependencies": {
     "@ryansonshine/commitizen": "^4.2.8",
     "@ryansonshine/cz-conventional-changelog": "^3.3.4",


### PR DESCRIPTION
What a long time spent debugging this. Mysterious http 400's when your package name includes the word "download"