### PR TITLE
fix: use spec path for revivals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -356,9 +356,7 @@ export default class DownloadQueue {
         curSpec.createTime = Date.now();
 
         const [fileExists] = await Promise.all([
-          RNFS.exists(
-            this.pathFromId(curSpec.id, this.extensionFromUri(curSpec.url))
-          ),
+          RNFS.exists(curSpec.path),
           this.kvfs.write(this.keyFromId(curSpec.id), curSpec),
         ]);
         if (!curSpec.finished || !fileExists) {


### PR DESCRIPTION
This was a bug that caused older spec formats to fail (because the stored path was not the same as getting it from the pathid).
