### PR TITLE
feat: upgrade to @kesha-antonov/react-native-background-downloader 2.6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Automatically download files from urls, even in the background, and keep them lo
 ## Install
 
 First install peer dependencies:
-* [react-native-background-downloader](https://github.com/kesha-antonov/react-native-background-downloader#readme). Be sure to follow the sneakily-hidden [extra iOS step for AppDelegate.m](https://github.com/kesha-antonov/react-native-background-downloader#ios---extra-mandatory-step) or else your background tasks will be canceled by the OS.
+* [@kesha-antonov/react-native-background-downloader](https://github.com/kesha-antonov/react-native-background-downloader#readme). Be sure to follow the sneakily-hidden [extra iOS step for AppDelegate.m](https://github.com/kesha-antonov/react-native-background-downloader#ios---extra-mandatory-step) or else your background tasks will be canceled by the OS.
 * [react-native-fs](https://github.com/itinance/react-native-fs#readme)
 * [@react-native-async-storage/async-storage](https://github.com/react-native-async-storage/async-storage#readme)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "react-uuid": "^2.0.0"
       },
       "devDependencies": {
+        "@kesha-antonov/react-native-background-downloader": "^2.6.9",
+        "@react-native-async-storage/async-storage": "^1.17.11",
         "@react-native-community/netinfo": "^9.3.7",
         "@ryansonshine/commitizen": "^4.2.8",
         "@ryansonshine/cz-conventional-changelog": "^3.3.4",
@@ -43,9 +45,11 @@
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "github:react-native-async-storage/async-storage",
-        "react-native-background-downloader": "github:kesha-antonov/react-native-background-downloader",
         "react-native-fs": "^2.20.0"
       }
+    },
+    "@kesha-antonov/react-native-background-downloader": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -2698,6 +2702,15 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@kesha-antonov/react-native-background-downloader": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@kesha-antonov/react-native-background-downloader/-/react-native-background-downloader-2.6.9.tgz",
+      "integrity": "sha512-gn8dpZtE+cBL2KTwWTqxRz7MJ4iHC/hpY5St7wBxZDiB3+Ej1EsY4rFDnFJmpj3xlbj7EVV9bJIIVJvzOexWcA==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native": ">=0.57.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -2867,9 +2880,9 @@
     },
     "node_modules/@react-native-async-storage/async-storage": {
       "version": "1.17.11",
-      "resolved": "git+ssh://git@github.com/react-native-async-storage/async-storage.git#cfa67c6ca9a1134cfa9380a1b88e26af011fe689",
-      "license": "MIT",
-      "peer": true,
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz",
+      "integrity": "sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==",
+      "dev": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -11204,7 +11217,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },
@@ -11216,7 +11229,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15706,15 +15719,6 @@
         "react": "18.2.0"
       }
     },
-    "node_modules/react-native-background-downloader": {
-      "version": "2.4.2",
-      "resolved": "git+ssh://git@github.com/kesha-antonov/react-native-background-downloader.git#463319f6e4b153daf6f6f6fde50a8bf63043dd0c",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "react-native": ">=0.57.0"
-      }
-    },
     "node_modules/react-native-codegen": {
       "version": "0.71.3",
       "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.71.3.tgz",
@@ -20193,6 +20197,13 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@kesha-antonov/react-native-background-downloader": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@kesha-antonov/react-native-background-downloader/-/react-native-background-downloader-2.6.9.tgz",
+      "integrity": "sha512-gn8dpZtE+cBL2KTwWTqxRz7MJ4iHC/hpY5St7wBxZDiB3+Ej1EsY4rFDnFJmpj3xlbj7EVV9bJIIVJvzOexWcA==",
+      "dev": true,
+      "requires": {}
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -20344,9 +20355,10 @@
       }
     },
     "@react-native-async-storage/async-storage": {
-      "version": "git+ssh://git@github.com/react-native-async-storage/async-storage.git#cfa67c6ca9a1134cfa9380a1b88e26af011fe689",
-      "from": "@react-native-async-storage/async-storage@github:react-native-async-storage/async-storage",
-      "peer": true,
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz",
+      "integrity": "sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==",
+      "dev": true,
       "requires": {
         "merge-options": "^3.0.4"
       }
@@ -26787,7 +26799,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "is-plain-obj": "^2.1.0"
       },
@@ -26796,7 +26808,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -30201,12 +30213,6 @@
           }
         }
       }
-    },
-    "react-native-background-downloader": {
-      "version": "git+ssh://git@github.com/kesha-antonov/react-native-background-downloader.git#463319f6e4b153daf6f6f6fde50a8bf63043dd0c",
-      "from": "react-native-background-downloader@github:kesha-antonov/react-native-background-downloader",
-      "peer": true,
-      "requires": {}
     },
     "react-native-codegen": {
       "version": "0.71.3",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "typescript": "^4.2.4"
   },
   "peerDependencies": {
-    "@react-native-async-storage/async-storage": "github:react-native-async-storage/async-storage",
-    "react-native-background-downloader": "github:kesha-antonov/react-native-background-downloader",
+    "@kesha-antonov/react-native-background-downloader": "^2.6.9",
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "react-native-fs": "^2.20.0"
   },
   "config": {


### PR DESCRIPTION
BREAKING CHANGE: This includes implementing its new way of restoring downloads upon app restart. We've moved to requiring "@kesha-antonov/react-native-background-downloader" as opposed to pulling it directly from GitHub.