### PR TITLE
fix: guard begin/progress callbacks against removed tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -731,6 +731,12 @@ export default class DownloadQueue {
   private addTask(url: string, task: DownloadTask) {
     task
       .begin(data => {
+        // The task may have been removed (e.g. via removeUrl) before a trailing
+        // begin callback already queued on the JS bridge fires. Like doDone, we
+        // no-op so we don't notify clients about a download that's gone.
+        if (!this.tasks.some(t => t.id === task.id)) {
+          return;
+        }
         // Bug: https://github.com/kesha-antonov/react-native-background-downloader/issues/23
         // Basically the downloader doesn't respect the pause() if we call it
         // right after download(). So we end up having to pause only after the
@@ -742,6 +748,11 @@ export default class DownloadQueue {
         this.handlers?.onBegin?.(url, data.expectedBytes);
       })
       .progress(({ bytesDownloaded, bytesTotal }) => {
+        // See note in begin() above: a trailing progress callback can fire after
+        // the task has been removed, so we no-op to avoid re-notifying clients.
+        if (!this.tasks.some(t => t.id === task.id)) {
+          return;
+        }
         // Bug: https://github.com/kesha-antonov/react-native-background-downloader/issues/23
         // See note in begin() above. We can get progress callbacks even without
         // begin() (e.g. in the case of resuming a background task upon launch).

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2507,5 +2507,56 @@ describe("DownloadQueue", () => {
       ).resolves.not.toThrow();
       expect(handlers.onDone).not.toHaveBeenCalled();
     });
+
+    it("should not call begin/progress after a url has been removed", async () => {
+      const handlers: DownloadQueueHandlers = {
+        onBegin: jest.fn(),
+        onProgress: jest.fn(),
+        onWillRemove: jest.fn(() => Promise.resolve()),
+      };
+      const queue = new DownloadQueue();
+
+      (download as jest.Mock).mockImplementation(
+        (spec: { id: string }): TaskWithHandlers => {
+          return Object.assign(task, {
+            id: spec.id,
+            begin: jest.fn(handler => {
+              task._begin = handler;
+              return task;
+            }),
+            progress: jest.fn(handler => {
+              task._progress = handler;
+              return task;
+            }),
+          });
+        }
+      );
+
+      await queue.init({ domain: "mydomain", handlers });
+      await queue.addUrl("http://foo.com/a.mp3");
+
+      // Drive the download to a partial progress.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      task._begin!({ expectedBytes: 1000, headers: {} });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      task._progress!({ bytesDownloaded: 420, bytesTotal: 1000 });
+      expect(handlers.onBegin).toHaveBeenCalledTimes(1);
+      expect(handlers.onProgress).toHaveBeenCalledTimes(1);
+
+      // Remove the url, which fires onWillRemove and stops the task.
+      await queue.removeUrl("http://foo.com/a.mp3");
+      expect(handlers.onWillRemove).toHaveBeenCalledTimes(1);
+
+      // Trailing begin/progress callbacks can still fire on the now-removed task
+      // (e.g. events already queued on the JS bridge). They must not re-notify
+      // the client, which would leave their UI stuck at a stale fraction.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      task._begin!({ expectedBytes: 1000, headers: {} });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      task._progress!({ bytesDownloaded: 420, bytesTotal: 1000 });
+
+      expect(handlers.onBegin).toHaveBeenCalledTimes(1);
+      expect(handlers.onProgress).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a race where trailing `begin`/`progress` events already queued on the JS bridge could fire *after* a url was removed via `removeUrl`/`setQueue`. Because `removeTask` only splices the task out of `this.tasks` (it doesn't detach the bound `.begin()`/`.progress()` closures) and `task.stop()` doesn't synchronously flush queued callbacks, a stale `onProgress` could re-fire after `onWillRemove` — leaving the consumer's UI stuck at a stale fraction forever.
- Guards both callbacks to no-op once the task is no longer in `this.tasks`, matching how `doDone` and the error path already guard. The existing `if (!this.active) task.pause()` behavior is preserved for live tasks.

## Test plan
- [x] New regression test: drives a download to partial progress, removes the url (fires `onWillRemove`), then fires trailing `begin`/`progress` on the removed task and asserts neither handler fires again. Fails before the fix, passes after.
- [x] `npm test` — 159 passed, 100% coverage.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)